### PR TITLE
33 training data in workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,4 +42,4 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest
+        pytest --cov=dtaianomaly --cov-report term-missing

--- a/docs/additional_information/contributing.rst
+++ b/docs/additional_information/contributing.rst
@@ -242,6 +242,7 @@ BaseDetector
 
 | |check_box| Have you added a ``.py`` in ``dtaianomaly/anomaly_detection`` named identical to the anomaly detector?
 | |check_box| Does the file contain a class named as the anomaly detector, which inherits :py:class:`~dtaianomaly.anomaly_detection.BaseDetector`?
+| |check_box| Does the constructor call ``super().__init__(Supervision)`` with the correct supervision type?
 | |check_box| Are all hyperparameters checked to be of the correct type and belong to the domain?
 | |check_box| Are all hyperparameters set as an attribute of the object (necessary for ``__str__()`` method)?
 | |check_box| Have you implemented the :py:func:`~dtaianomaly.anomaly_detection.BaseDetector.fit()` method?

--- a/docs/api/anomaly_detection.rst
+++ b/docs/api/anomaly_detection.rst
@@ -54,6 +54,8 @@ BaseDetector
 .. autoclass:: dtaianomaly.anomaly_detection.BaseDetector
    :members:
 
+.. autoclass:: dtaianomaly.anomaly_detection.Supervision
+
 
 Utilities
 ---------

--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -7,6 +7,7 @@ Data module
     :members:
 
 .. autoclass:: dtaianomaly.data.DataSet
+    :members:
 
 Synthetic data
 --------------

--- a/docs/getting_started/examples/custom_models.rst
+++ b/docs/getting_started/examples/custom_models.rst
@@ -90,7 +90,7 @@ and easily analyze multiple detectors simultaneously.
         def _load(self)-> DataSet:
             """ Read a data frame with the data in column 'X' and the labels in column 'y'. """
             df = pd.read_clipboard(self.path)
-            return DataSet(x=df['X'].values, y=df['y'].values)
+            return DataSet(df['X'].values, df['y'].values)
 
 .. _custom-preprocessor:
 

--- a/dtaianomaly/__init__.py
+++ b/dtaianomaly/__init__.py
@@ -1,7 +1,1 @@
-from . import evaluation
-from . import preprocessing
-from . import data
-from . import pipeline
-from . import thresholding
-from . import workflow
-from . import anomaly_detection
+

--- a/dtaianomaly/anomaly_detection/BaseDetector.py
+++ b/dtaianomaly/anomaly_detection/BaseDetector.py
@@ -1,12 +1,27 @@
 import abc
 import os.path
 import pickle
+import enum
 import numpy as np
 from pathlib import Path
 from typing import Optional, Union
 
 from dtaianomaly import utils
 from dtaianomaly.PrettyPrintable import PrettyPrintable
+
+
+class Supervision(enum.Enum):
+    """
+    An enum for the different supervision types for anomaly detectors.
+    Valid supervision types are:
+
+    - ``Unsupervised``: the anomaly detector does not need any labels or training data.
+    - ``Semi-supervised``: The anomaly detector requires *normal* training data, but no training labels.
+    - ``Supervised``: The anomaly detector requires both training data and training labels. The training data may contain anomalies.
+    """
+    UNSUPERVISED = 1
+    SEMI_SUPERVISED = 2
+    SUPERVISED = 3
 
 
 class BaseDetector(PrettyPrintable):
@@ -17,7 +32,18 @@ class BaseDetector(PrettyPrintable):
     specific anomaly detectors. User-defined detectors
     can be used throughout the ``dtaianomaly`` by extending
     this base class.
+
+    Parameters
+    ----------
+    supervision: Supervision
+        The type of supervision this anomaly detector requires.
     """
+    supervision: Supervision
+
+    def __init__(self, supervision: Supervision):
+        if not isinstance(supervision, Supervision):
+            raise TypeError("'supervision' should be a valid 'Supervision' type!")
+        self.supervision = supervision
 
     @abc.abstractmethod
     def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'BaseDetector':

--- a/dtaianomaly/anomaly_detection/MatrixProfileDetector.py
+++ b/dtaianomaly/anomaly_detection/MatrixProfileDetector.py
@@ -5,7 +5,7 @@ from typing import Optional, Union
 from sklearn.exceptions import NotFittedError
 
 from dtaianomaly import utils
-from dtaianomaly.anomaly_detection.BaseDetector import BaseDetector
+from dtaianomaly.anomaly_detection.BaseDetector import BaseDetector, Supervision
 from dtaianomaly.anomaly_detection.windowing_utils import reverse_sliding_window, check_is_valid_window_size, compute_window_size
 
 
@@ -82,7 +82,7 @@ class MatrixProfileDetector(BaseDetector):
                  p: float = 2.0,
                  k: int = 1,
                  novelty: bool = False) -> None:
-        super().__init__()
+        super().__init__(Supervision.UNSUPERVISED)
 
         check_is_valid_window_size(window_size)
 

--- a/dtaianomaly/anomaly_detection/MedianMethod.py
+++ b/dtaianomaly/anomaly_detection/MedianMethod.py
@@ -3,7 +3,7 @@ import numpy as np
 from typing import Optional
 
 from dtaianomaly import utils
-from dtaianomaly.anomaly_detection.BaseDetector import BaseDetector
+from dtaianomaly.anomaly_detection.BaseDetector import BaseDetector, Supervision
 
 
 class MedianMethod(BaseDetector):
@@ -51,7 +51,7 @@ class MedianMethod(BaseDetector):
     neighborhood_size_after: Optional[int]
 
     def __init__(self, neighborhood_size_before: int, neighborhood_size_after: Optional[int] = None):
-        super().__init__()
+        super().__init__(Supervision.UNSUPERVISED)
 
         if not isinstance(neighborhood_size_before, int) or isinstance(neighborhood_size_before, bool):
             raise TypeError("`neighborhood_size_before` should be an integer")

--- a/dtaianomaly/anomaly_detection/PyODAnomalyDetector.py
+++ b/dtaianomaly/anomaly_detection/PyODAnomalyDetector.py
@@ -4,7 +4,7 @@ import numpy as np
 from typing import Optional, Union
 from sklearn.exceptions import NotFittedError
 from pyod.models.base import BaseDetector as PyODBaseDetector
-from dtaianomaly.anomaly_detection.BaseDetector import BaseDetector
+from dtaianomaly.anomaly_detection.BaseDetector import BaseDetector, Supervision
 from dtaianomaly.anomaly_detection.windowing_utils import sliding_window, reverse_sliding_window, check_is_valid_window_size, compute_window_size
 from dtaianomaly import utils
 
@@ -49,6 +49,8 @@ class PyODAnomalyDetector(BaseDetector, abc.ABC):
     pyod_detector_: PyODBaseDetector
 
     def __init__(self, window_size: Union[str, int], stride: int = 1, **kwargs):
+        super().__init__(Supervision.UNSUPERVISED)
+
         check_is_valid_window_size(window_size)
 
         if not isinstance(stride, int) or isinstance(stride, bool):

--- a/dtaianomaly/anomaly_detection/__init__.py
+++ b/dtaianomaly/anomaly_detection/__init__.py
@@ -9,7 +9,7 @@ We refer to the `documentation <https://dtaianomaly.readthedocs.io/en/stable/get
 for more information regarding detecting anomalies using ``dtaianomaly``.
 """
 
-from .BaseDetector import BaseDetector, load_detector
+from .BaseDetector import BaseDetector, Supervision, load_detector
 from .windowing_utils import sliding_window, reverse_sliding_window, check_is_valid_window_size, compute_window_size
 
 from .baselines import AlwaysNormal, AlwaysAnomalous, RandomDetector
@@ -24,6 +24,7 @@ from .MedianMethod import MedianMethod
 __all__ = [
     # Base
     'BaseDetector',
+    'Supervision',
     'load_detector',
 
     # Sliding window

--- a/dtaianomaly/anomaly_detection/baselines/baselines.py
+++ b/dtaianomaly/anomaly_detection/baselines/baselines.py
@@ -2,7 +2,7 @@
 import numpy as np
 from typing import Optional
 from dtaianomaly import utils
-from dtaianomaly.anomaly_detection.BaseDetector import BaseDetector
+from dtaianomaly.anomaly_detection.BaseDetector import BaseDetector, Supervision
 
 
 class AlwaysNormal(BaseDetector):
@@ -11,6 +11,9 @@ class AlwaysNormal(BaseDetector):
     This detector should only be used for sanity-check, and not to effectively
     detect anomalies in time series data.
     """
+
+    def __init__(self):
+        super().__init__(Supervision.UNSUPERVISED)
 
     def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'AlwaysNormal':
         """
@@ -60,6 +63,9 @@ class AlwaysAnomalous(BaseDetector):
     This detector should only be used for sanity-check, and not to effectively
     detect anomalies in time series data.
     """
+
+    def __init__(self):
+        super().__init__(Supervision.UNSUPERVISED)
 
     def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'AlwaysAnomalous':
         """
@@ -117,6 +123,7 @@ class RandomDetector(BaseDetector):
     seed: Optional[int]
 
     def __init__(self, seed: Optional[int] = None):
+        super().__init__(Supervision.UNSUPERVISED)
         self.seed = seed
 
     def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'RandomDetector':

--- a/dtaianomaly/data/DataSet.py
+++ b/dtaianomaly/data/DataSet.py
@@ -1,7 +1,8 @@
 
 import numpy as np
 from typing import Optional
-from dtaianomaly.anomaly_detection.BaseDetector import BaseDetector
+from dtaianomaly.utils import is_valid_array_like, is_univariate, get_dimension
+from dtaianomaly.anomaly_detection.BaseDetector import BaseDetector, Supervision
 
 
 class DataSet:
@@ -13,7 +14,7 @@ class DataSet:
     Parameters
     ----------
     X_test: array-like of shape (n_samples_test, n_attributes)
-        The test time series data
+        The test time series data.
     y_test: array-like of shape (n_samples_test)
         The ground truth anomaly labels of the test data.
     X_train: array-like of shape (n_samples_train, n_attributes), optional
@@ -30,6 +31,17 @@ class DataSet:
     X_train: np.ndarray = None
     y_train: np.ndarray = None
 
+    def __init__(self,
+                 X_test: np.ndarray,
+                 y_test: np.ndarray,
+                 X_train: np.ndarray = None,
+                 y_train: np.ndarray = None):
+        self.check_is_valid(X_test, y_test, X_train, y_train)
+        self.X_test = X_test
+        self.y_test = y_test
+        self.X_train = X_train
+        self.y_train = y_train
+
     @property
     def x(self) -> np.ndarray:
         """ Temporary method to be compatible with existing code. """
@@ -40,9 +52,104 @@ class DataSet:
         """ Temporary method to be compatible with existing code. """
         return self.y_test
 
+    @staticmethod
+    def check_is_valid(
+            X_test: np.ndarray,
+            y_test: np.ndarray,
+            X_train: Optional[np.ndarray],
+            y_train: Optional[np.ndarray]) -> None:
+        """
+        Checks if the given elements refer o a valid ``DataSet``. If the elements
+        would not give a valid ``DataSet``, then a ``ValueError`` is raised.
+
+        Parameters
+        ----------
+        X_test: array-like of shape (n_samples_test, n_attributes)
+            The test time series data.
+        y_test: array-like of shape (n_samples_test)
+            The ground truth anomaly labels of the test data.
+        X_train: array-like of shape (n_samples_train, n_attributes) or ``None``
+            The train time series data. Note that, even though ``X_train`` can
+            be ``None``, it must be provided.
+        y_train: array-like of shape (n_samples_train) or ``None``.
+            The ground truth anomaly labels of the train data. Note that, even
+            though ``y_train`` can be ``None``, it must be provided.
+
+        Raises
+        ------
+        ValueError:
+            If the given variables would not lead to a valid ``DataSet``. This is the
+            case if:
+
+            - If ``X_test`` or ``y_test`` are not valid array-like.
+            - If ``y_test`` is not univariate and has a value different from 0 or 1.
+            - If ``X_test`` and ``y_test`` consist of a different number of samples.
+            - If ``X_train`` is not ``None``, but it is not a valid array-like.
+            - If ``X_train`` is not ``None`` and consists of a different number of
+              attributes than ``X_test``.
+            - If ``y_train`` is not ``None`` but ``X_train`` is ``None``.
+            - If ``y_train`` is not ``None`` but it is not a valid array-like.
+            - If ``y_train`` is not ``None``, but it is not univariate and has a .
+              value different from 0 or 1.
+            - If ``y_train`` is not ``None`` but consists of a different number of
+              samples than ``X_train``.
+        """
+        # Check test data
+        if not is_valid_array_like(X_test):
+            raise ValueError('The test data must be a valid array like!')
+
+        # Check test labels
+        if not is_valid_array_like(y_test):
+            raise ValueError('The test labels must be a valid array like!')
+        if not is_univariate(y_test):
+            raise ValueError('There can only be one label for each observation in the test data!')
+        if not np.all(np.isin(y_test, [0, 1])):
+            raise ValueError('The test labels must be binary!')
+        if not y_test.shape[0] == X_test.shape[0]:
+            raise ValueError('The test data and labels must consist of the same number of observations!')
+
+        # Check the train data
+        if X_train is not None:
+            if not is_valid_array_like(X_train):
+                raise ValueError('The train data must be a valid array like!')
+            if get_dimension(X_test) != get_dimension(X_train):
+                raise ValueError('The test and train data must consist of the same number of features!')
+
+        # Check the train data
+        if y_train is not None:
+            if X_train is None:
+                raise ValueError('There can not be any train labels if there is no train data!')
+            if not is_valid_array_like(y_train):
+                raise ValueError('The train labels must be a valid array like!')
+            if not is_univariate(y_train):
+                raise ValueError('There can only be one label for each observation in the train data!')
+            if not np.all(np.isin(y_train, [0, 1])):
+                raise ValueError('The test labels must be binary!')
+            if not X_train.shape[0] == y_train.shape[0]:
+                raise ValueError('The train data and labels must consist of the same number of observations!')
+
     def is_valid(self) -> bool:
-        # Check if this DataSet object is valid (correct dimensions, whether train data is given, ...)
-        return True
+        """
+        Checks whether this ``DataSet`` is valid or not.
+
+        Returns
+        -------
+        is_valid: bool
+            True if and only if this instance is valid, i.e., if the attributes
+            ``X_test``, ``y_test``, ``X_train`` and ``y_train`` of this instance
+            pass all the checks of :py:meth:`~dtaianomaly.data.DataSet.check_is_valid`.
+        """
+        try:
+            self.check_is_valid(
+                X_test=self.X_test,
+                y_test=self.y_test,
+                X_train=self.X_train,
+                y_train=self.y_train
+            )
+            return True
+
+        except ValueError:
+            return False
 
     def is_compatible(self, detector: BaseDetector) -> bool:
         """
@@ -66,15 +173,16 @@ class DataSet:
             - This ``DataSet`` contains training data and labels, then supervised,
               unsupervised and semi-supervised anomaly detectors are compatible.
         """
-
         # If there is no train data given at all, then only unsupervised detectors are compatible
         if self.X_train is None and self.y_train is None:
-            return True
-
+            return detector.supervision in [Supervision.UNSUPERVISED]
         # If train data is given but no train labels, then either unsupervised or semi-supervised detectors are compatible
         elif self.X_train is not None and self.y_train is None:
-            return True
-
+            return detector.supervision in [Supervision.UNSUPERVISED, Supervision.SEMI_SUPERVISED]
         # If the train data and train labels are given, then all detectors are compatible.
         else:
-            return True
+            return detector.supervision in [
+                Supervision.UNSUPERVISED,
+                Supervision.SEMI_SUPERVISED,
+                Supervision.SUPERVISED
+            ]

--- a/dtaianomaly/data/DataSet.py
+++ b/dtaianomaly/data/DataSet.py
@@ -1,19 +1,80 @@
 
 import numpy as np
-from typing import NamedTuple
+from typing import Optional
+from dtaianomaly.anomaly_detection.BaseDetector import BaseDetector
 
 
-class DataSet(NamedTuple):
+class DataSet:
     """
     A class for time series anomaly detection data sets. These
-    consist of the raw data itself and the ground truth labels.
+    consist of the raw data for training and testing anomaly
+    detectors, as well as the respective ground truth labels.
 
     Parameters
     ----------
-    x: array-like of shape (n_samples, n_features)
-        The time series.
-    y: array-like of shape (n_samples)
-        The ground truth anomaly labels.
+    X_test: array-like of shape (n_samples_test, n_attributes)
+        The test time series data
+    y_test: array-like of shape (n_samples_test)
+        The ground truth anomaly labels of the test data.
+    X_train: array-like of shape (n_samples_train, n_attributes), optional
+        The train time series. If not given, then the test data will
+        be used for training and the data is only compatible with
+        unsupervised anomaly detectors.
+    y_train: array-like of shape (n_samples_train), optional
+        The ground truth anomaly labels of the training data. If not given,
+        either the train data should not be given either, or the train
+        data is assumed to consist of only normal data.
     """
-    x: np.ndarray
-    y: np.ndarray
+    X_test: np.ndarray
+    y_test: np.ndarray
+    X_train: np.ndarray = None
+    y_train: np.ndarray = None
+
+    @property
+    def x(self) -> np.ndarray:
+        """ Temporary method to be compatible with existing code. """
+        return self.X_test
+
+    @property
+    def y(self) -> np.ndarray:
+        """ Temporary method to be compatible with existing code. """
+        return self.y_test
+
+    def is_valid(self) -> bool:
+        # Check if this DataSet object is valid (correct dimensions, whether train data is given, ...)
+        return True
+
+    def is_compatible(self, detector: BaseDetector) -> bool:
+        """
+        Checks if the given anomaly detector is compatible with this ``DataSet``.
+
+        Parameters
+        ----------
+        detector: BaseDetector
+            The anomaly detector to check if it is compatible with this ``DataSet``.
+
+        Returns
+        -------
+        is_compatible: bool
+            True if and only if the given anomaly detector is compatible with
+            this ``DataSet``. The detector is compatible if
+
+            - This ``DataSet`` does not contain any training data or training labels,
+              only unsupervised anomaly detectors are compatible
+            - This ``DataSet`` contains training data but no training labels, then
+              unsupervised and semi-supervised anomaly detectors are compatible.
+            - This ``DataSet`` contains training data and labels, then supervised,
+              unsupervised and semi-supervised anomaly detectors are compatible.
+        """
+
+        # If there is no train data given at all, then only unsupervised detectors are compatible
+        if self.X_train is None and self.y_train is None:
+            return True
+
+        # If train data is given but no train labels, then either unsupervised or semi-supervised detectors are compatible
+        elif self.X_train is not None and self.y_train is None:
+            return True
+
+        # If the train data and train labels are given, then all detectors are compatible.
+        else:
+            return True

--- a/dtaianomaly/data/DataSet.py
+++ b/dtaianomaly/data/DataSet.py
@@ -42,16 +42,6 @@ class DataSet:
         self.X_train = X_train
         self.y_train = y_train
 
-    @property
-    def x(self) -> np.ndarray:
-        """ Temporary method to be compatible with existing code. """
-        return self.X_test
-
-    @property
-    def y(self) -> np.ndarray:
-        """ Temporary method to be compatible with existing code. """
-        return self.y_test
-
     @staticmethod
     def check_is_valid(
             X_test: np.ndarray,

--- a/dtaianomaly/data/DataSet.py
+++ b/dtaianomaly/data/DataSet.py
@@ -1,0 +1,19 @@
+
+import numpy as np
+from typing import NamedTuple
+
+
+class DataSet(NamedTuple):
+    """
+    A class for time series anomaly detection data sets. These
+    consist of the raw data itself and the ground truth labels.
+
+    Parameters
+    ----------
+    x: array-like of shape (n_samples, n_features)
+        The time series.
+    y: array-like of shape (n_samples)
+        The ground truth anomaly labels.
+    """
+    x: np.ndarray
+    y: np.ndarray

--- a/dtaianomaly/data/LazyDataLoader.py
+++ b/dtaianomaly/data/LazyDataLoader.py
@@ -1,26 +1,10 @@
 import abc
 import os
-import numpy as np
 from pathlib import Path
-from typing import NamedTuple, List, Type, Union
+from typing import List, Type, Union
 
+from dtaianomaly.data.DataSet import DataSet
 from dtaianomaly.PrettyPrintable import PrettyPrintable
-
-
-class DataSet(NamedTuple):
-    """
-    A class for time series anomaly detection data sets. These
-    consist of the raw data itself and the ground truth labels.
-
-    Parameters
-    ----------
-    x: array-like of shape (n_samples, n_features)
-        The time series.
-    y: array-like of shape (n_samples)
-        The ground truth anomaly labels.
-    """
-    x: np.ndarray
-    y: np.ndarray
 
 
 class LazyDataLoader(PrettyPrintable):

--- a/dtaianomaly/data/UCRLoader.py
+++ b/dtaianomaly/data/UCRLoader.py
@@ -28,4 +28,4 @@ class UCRLoader(LazyDataLoader):
         y = np.zeros(shape=X.shape, dtype=np.int8)
         y[onset:offset] = 1
 
-        return DataSet(x=X, y=y)
+        return DataSet(X_test=X, y_test=y)

--- a/dtaianomaly/data/UCRLoader.py
+++ b/dtaianomaly/data/UCRLoader.py
@@ -27,8 +27,9 @@ class UCRLoader(LazyDataLoader):
         X_test = X[train_test_split:]
 
         # To ensure the file extensions gets ignored
-        y_test = np.zeros(shape=X_test.shape, dtype=int)
-        y_test[start_anomaly:end_anomaly] = 1
+        y = np.zeros(shape=X.shape[0], dtype=int)
+        y[start_anomaly:end_anomaly] = 1
+        y_test = y[train_test_split:]
 
         # Return a DataSet object
         return DataSet(X_test=X_test, y_test=y_test, X_train=X_train)

--- a/dtaianomaly/data/UCRLoader.py
+++ b/dtaianomaly/data/UCRLoader.py
@@ -1,6 +1,7 @@
 
 import numpy as np
-from dtaianomaly.data.data import LazyDataLoader, DataSet
+from dtaianomaly.data.DataSet import DataSet
+from dtaianomaly.data.LazyDataLoader import LazyDataLoader
 
 
 class UCRLoader(LazyDataLoader):

--- a/dtaianomaly/data/__init__.py
+++ b/dtaianomaly/data/__init__.py
@@ -6,7 +6,8 @@ executing a pipeline or workflow. It can be imported as follows:
 
 Custom data loaders can be implemented by extending :py:class:`~dtaianomaly.data.LazyDataLoader`.
 """
-from .data import LazyDataLoader, from_directory, DataSet
+from .LazyDataLoader import LazyDataLoader, from_directory
+from .DataSet import DataSet
 from .synthetic import make_sine_wave, demonstration_time_series
 from .UCRLoader import UCRLoader
 

--- a/dtaianomaly/pipeline/Pipeline.py
+++ b/dtaianomaly/pipeline/Pipeline.py
@@ -36,7 +36,7 @@ class Pipeline(BaseDetector):
             raise TypeError("preprocessor expects a Preprocessor object or list of Preprocessors")
         if not isinstance(detector, BaseDetector):
             raise TypeError("detector expects a BaseDetector object")
-        super().__init__()        
+        super().__init__(detector.supervision)
         
         if isinstance(preprocessor, list):
             self.preprocessor = ChainedPreprocessor(preprocessor)

--- a/dtaianomaly/utils.py
+++ b/dtaianomaly/utils.py
@@ -75,7 +75,7 @@ def is_univariate(X: np.ndarray) -> bool:
     Parameters
     ----------
     X: array-like of shape (n_samples, n_attributes)
-        The time series data to check if it is multivariate.
+        The time series data to check if it is univariate.
 
     Returns
     -------
@@ -83,9 +83,25 @@ def is_univariate(X: np.ndarray) -> bool:
         True if and only if the given time series has only one dimension,
         or if the second dimension of the time series is of size 1.
     """
+    return get_dimension(X) == 1
+
+
+def get_dimension(X: np.ndarray) -> int:
+    """
+    Get the dimension of the given array.
+
+    Parameters
+    ----------
+    X: array-like of shape (n_samples, n_attributes)
+        The time series data to get the dimension from
+
+    Returns
+    -------
+    n_attributes: int
+        The number of attributes in the given time series.
+    """
     X = np.array(X)
     if len(X.shape) == 1:
-        return True
-
+        return 1
     else:
-        return X.shape[1] == 1
+        return X.shape[1]

--- a/dtaianomaly/workflow/error_logging.py
+++ b/dtaianomaly/workflow/error_logging.py
@@ -7,7 +7,7 @@ from dtaianomaly.data import LazyDataLoader
 from dtaianomaly.pipeline import Pipeline
 
 
-def log_error(error_log_path: str, exception: Exception, data_loader: LazyDataLoader, pipeline: Pipeline = None) -> str:
+def log_error(error_log_path: str, exception: Exception, data_loader: LazyDataLoader, pipeline: Pipeline = None, fit_on_X_train: bool = True) -> str:
 
     # Ensure the directory exists
     os.makedirs(error_log_path, exist_ok=True)
@@ -71,6 +71,10 @@ def log_error(error_log_path: str, exception: Exception, data_loader: LazyDataLo
                              '    preprocessor=preprocessor,\n'
                              '    detector=detector\n'
                              ')\n')
-            error_file.write('y_pred = pipeline.fit(data.x, data.y).predict_proba(data.x)\n\n')
+            if fit_on_X_train:
+                train_data = 'X_train'
+            else:
+                train_data = 'X_test'
+            error_file.write(f'y_pred = pipeline.fit(data.{train_data}, data.y_train).predict_proba(data.X_test)\n\n')
 
     return os.path.abspath(file_path)

--- a/notebooks/Custom-models.ipynb
+++ b/notebooks/Custom-models.ipynb
@@ -107,8 +107,8 @@
     "        \n",
     "    def _load(self)-> DataSet:\n",
     "        \"\"\" Read a data frame with the data in column 'X' and the labels in column 'y'. \"\"\"\n",
-    "        df = pd.read_clipboard(self.path)\n",
-    "        return DataSet(x=df['X'].values, y=df['y'].values)"
+    "        df = pd.read_csv(self.path)\n",
+    "        return DataSet(df['X'].values, df['y'].values)"
    ],
    "id": "798a876f13a67410",
    "outputs": [],

--- a/notebooks/Industrial-anomaly-detection.ipynb
+++ b/notebooks/Industrial-anomaly-detection.ipynb
@@ -83,7 +83,9 @@
    "source": [
     "#### Data loading\n",
     "\n",
-    "The first step to detect anomalies is to load the data. The entire dataset can be downloaded from [1]. Once the data has been downloaded and unzipped (as well as unzipping the inner zip-files), we can start loading the data. For nicely structured data, you could simply call something like ``pd.read_csv(\"path-to-data.csv\")``. However, the Penmanshiel dataset consists of a large number of files, which should be read, aggregated and formatted. For these datasets, ``dtaianomaly`` offers the ``LazyDataLoader``, a class for implementing the logic to read a dataset, after which the data can be read using a single function call. Below, we implement the ``PenmanshielDataLoader`` as a child of the ``LazyDataLoader``, which will format the observational data and ground truth labels in numpy arrays. Additionally, we implemented logic to split the dataset into a train and test set. \n",
+    "The first step to detect anomalies is to load the data. The entire dataset can be downloaded from [1]. Once the data has been downloaded and unzipped (as well as unzipping the inner zip-files), we can start loading the data. For nicely structured data, you could simply call something like ``pd.read_csv(\"path-to-data.csv\")``. However, the Penmanshiel dataset consists of a large number of files, which should be read, aggregated and formatted. For these datasets, ``dtaianomaly`` offers the ``LazyDataLoader``, a class for implementing the logic to read a dataset, after which the data can be read using a single function call. Below, we implement the ``PenmanshielDataLoader`` as a child of the ``LazyDataLoader``, which will format the observational data and ground truth labels in numpy arrays. \n",
+    "\n",
+    "Additionally, we implemented logic to split the dataset into a train and test set. It is also possible to use the internal train and test separation of a ``DataSet``, but we choose to not use this for this use case. The reason is that we want to verify the performance of various unsupervised anomaly detectors on a train set, and the use that detector to estimate the performance on the future test set. If we used the train and test set of a ``DataSet``, then we would evaluate all the anomaly detectors on the test set while being trained on the train set, without being able to do further predictions of the best anomaly detector on an addition data set. \n",
     "\n",
     "> Note that we implement the ``_load()`` method (with preceding underscore) instead of the ``load()`` method (without preceding underscore). That is because the ``LazyDataLoader`` automatically supports caching data depending on the ``do_caching`` parameter. This is especially beneficial for large datasets such as the penmanshiel wind turbine data. By implementing the ``_load()`` method, you do not have to worry about caching the data. "
    ],
@@ -165,9 +167,9 @@
     "        # Return either the train or test set \n",
     "        nb_instances_train_set = int(turbine_data.shape[0] * self.train_size)\n",
     "        if self.return_train_data:\n",
-    "            return DataSet(turbine_data.values[:nb_instances_train_set], anomalies.values[:nb_instances_train_set])\n",
+    "            return DataSet(X_test=turbine_data.values[:nb_instances_train_set], y_test=anomalies.values[:nb_instances_train_set])\n",
     "        else:\n",
-    "            return DataSet(turbine_data.values[nb_instances_train_set:], anomalies.values[nb_instances_train_set:])"
+    "            return DataSet(X_test=turbine_data.values[nb_instances_train_set:], y_test=anomalies.values[nb_instances_train_set:])"
    ],
    "id": "77039b48-b354-433b-8416-985a8909612a",
    "outputs": [],
@@ -176,7 +178,7 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "Now we can simply load the penmanshiel data by instantiating a ``PenmanshielDataLoader`` and calling the ``load()`` method, as is shown below. This method returns a ``DataSet``-object with ``x`` the raw time series data and ``y`` the ground truth anomaly labels. We will load both a train and test set, in which we use the first 10% of the data for training and the remaining 90% for testing. ",
+   "source": "Now we can simply load the penmanshiel data by instantiating a ``PenmanshielDataLoader`` and calling the ``load()`` method, as is shown below. This method returns a ``DataSet``-object with ``X`` the raw time series data and ``y`` the ground truth anomaly labels. We will load both a train and test set, in which we use the first 10% of the data for training and the remaining 90% for testing. ",
    "id": "ad4bc1293eee019a"
   },
   {

--- a/notebooks/Industrial-anomaly-detection.ipynb
+++ b/notebooks/Industrial-anomaly-detection.ipynb
@@ -165,9 +165,9 @@
     "        # Return either the train or test set \n",
     "        nb_instances_train_set = int(turbine_data.shape[0] * self.train_size)\n",
     "        if self.return_train_data:\n",
-    "            return DataSet(x=turbine_data.values[:nb_instances_train_set], y=anomalies.values[:nb_instances_train_set])\n",
+    "            return DataSet(turbine_data.values[:nb_instances_train_set], anomalies.values[:nb_instances_train_set])\n",
     "        else:\n",
-    "            return DataSet(x=turbine_data.values[nb_instances_train_set:], y=anomalies.values[nb_instances_train_set:])"
+    "            return DataSet(turbine_data.values[nb_instances_train_set:], anomalies.values[nb_instances_train_set:])"
    ],
    "id": "77039b48-b354-433b-8416-985a8909612a",
    "outputs": [],

--- a/tests/anomaly_detection/test_BaseDetector.py
+++ b/tests/anomaly_detection/test_BaseDetector.py
@@ -31,7 +31,7 @@ class NoDefinedSupervisionDetector(BaseDetector):
 class TestBaseDetector:
 
     @pytest.mark.parametrize('supervision', Supervision)
-    def test_valid_supervision(self, supervision):
+    def test_valid_supervision(self, supervision: Supervision):
         detector = NoDefinedSupervisionDetector(supervision)
         assert detector.supervision == supervision
 

--- a/tests/anomaly_detection/test_BaseDetector.py
+++ b/tests/anomaly_detection/test_BaseDetector.py
@@ -3,11 +3,14 @@ import os
 import pytest
 import numpy as np
 
-from dtaianomaly.anomaly_detection import BaseDetector, load_detector, baselines
+from dtaianomaly.anomaly_detection import BaseDetector, load_detector, baselines, Supervision
 from dtaianomaly import utils
 
 
 class InvalidConstantDecisionFunctionForPredictProba(BaseDetector):
+
+    def __init__(self):
+        super().__init__(Supervision.UNSUPERVISED)
 
     def fit(self, X, y=None):
         return self

--- a/tests/anomaly_detection/test_BaseDetector.py
+++ b/tests/anomaly_detection/test_BaseDetector.py
@@ -19,7 +19,25 @@ class InvalidConstantDecisionFunctionForPredictProba(BaseDetector):
         return np.ones(X.shape[0]) * 50
 
 
+class NoDefinedSupervisionDetector(BaseDetector):
+
+    def fit(self, X, y=None):
+        return self
+
+    def decision_function(self, X: np.ndarray) -> np.ndarray:
+        return np.ones(X.shape[0])
+
+
 class TestBaseDetector:
+
+    @pytest.mark.parametrize('supervision', Supervision)
+    def test_valid_supervision(self, supervision):
+        detector = NoDefinedSupervisionDetector(supervision)
+        assert detector.supervision == supervision
+
+    def test_invalid_supervision(self):
+        with pytest.raises(TypeError):
+            NoDefinedSupervisionDetector('supervision.SUPERVISED')
 
     def test_proba(self):
         data = np.random.standard_normal((50,))

--- a/tests/anomaly_detection/test_HistogramBasedOutlierScore.py
+++ b/tests/anomaly_detection/test_HistogramBasedOutlierScore.py
@@ -1,8 +1,12 @@
 
-from dtaianomaly.anomaly_detection import HistogramBasedOutlierScore
+from dtaianomaly.anomaly_detection import HistogramBasedOutlierScore, Supervision
 
 
 class TestHistogramBasedOutlierScore:
+
+    def test_supervision(self):
+        detector = HistogramBasedOutlierScore(1)
+        assert detector.supervision == Supervision.UNSUPERVISED
 
     def test_str(self):
         assert str(HistogramBasedOutlierScore(5)) == "HistogramBasedOutlierScore(window_size=5)"

--- a/tests/anomaly_detection/test_IsolationForest.py
+++ b/tests/anomaly_detection/test_IsolationForest.py
@@ -1,8 +1,12 @@
 
-from dtaianomaly.anomaly_detection import IsolationForest
+from dtaianomaly.anomaly_detection import IsolationForest, Supervision
 
 
 class TestIsolationForest:
+
+    def test_supervision(self):
+        detector = IsolationForest(1)
+        assert detector.supervision == Supervision.UNSUPERVISED
 
     def test_str(self):
         assert str(IsolationForest(5)) == "IsolationForest(window_size=5)"

--- a/tests/anomaly_detection/test_KNearestNeighbors.py
+++ b/tests/anomaly_detection/test_KNearestNeighbors.py
@@ -1,8 +1,12 @@
 
-from dtaianomaly.anomaly_detection import KNearestNeighbors
+from dtaianomaly.anomaly_detection import KNearestNeighbors, Supervision
 
 
 class TestKNearestNeighbors:
+
+    def test_supervision(self):
+        detector = KNearestNeighbors(1)
+        assert detector.supervision == Supervision.UNSUPERVISED
 
     def test_str(self):
         assert str(KNearestNeighbors(5)) == "KNearestNeighbors(window_size=5)"

--- a/tests/anomaly_detection/test_LocalOutlierFactor.py
+++ b/tests/anomaly_detection/test_LocalOutlierFactor.py
@@ -1,8 +1,12 @@
 
-from dtaianomaly.anomaly_detection import LocalOutlierFactor
+from dtaianomaly.anomaly_detection import LocalOutlierFactor, Supervision
 
 
 class TestLocalOutlierFactor:
+
+    def test_supervision(self):
+        detector = LocalOutlierFactor(1)
+        assert detector.supervision == Supervision.UNSUPERVISED
 
     def test_str(self):
         assert str(LocalOutlierFactor(5)) == "LocalOutlierFactor(window_size=5)"

--- a/tests/anomaly_detection/test_MatrixProfileDetector.py
+++ b/tests/anomaly_detection/test_MatrixProfileDetector.py
@@ -1,10 +1,14 @@
 
 import pytest
 from sklearn.exceptions import NotFittedError
-from dtaianomaly.anomaly_detection import MatrixProfileDetector
+from dtaianomaly.anomaly_detection import MatrixProfileDetector, Supervision
 
 
 class TestMatrixProfileDetector:
+
+    def test_supervision(self):
+        detector = MatrixProfileDetector(1)
+        assert detector.supervision == Supervision.UNSUPERVISED
 
     def test_initialize_non_int_window_size(self):
         with pytest.raises(ValueError):

--- a/tests/anomaly_detection/test_MedianMethod.py
+++ b/tests/anomaly_detection/test_MedianMethod.py
@@ -1,10 +1,14 @@
 
 import pytest
 import numpy as np
-from dtaianomaly.anomaly_detection import MedianMethod
+from dtaianomaly.anomaly_detection import MedianMethod, Supervision
 
 
 class TestMedianMethod:
+
+    def test_supervision(self):
+        detector = MedianMethod(15)
+        assert detector.supervision == Supervision.UNSUPERVISED
 
     def test_initialize(self):
         detector = MedianMethod(neighborhood_size_before=15, neighborhood_size_after=10)

--- a/tests/anomaly_detection/test_baselines.py
+++ b/tests/anomaly_detection/test_baselines.py
@@ -1,9 +1,13 @@
 
 import numpy as np
-from dtaianomaly.anomaly_detection import baselines
+from dtaianomaly.anomaly_detection import baselines, Supervision
 
 
 class TestAlwaysNormal:
+
+    def test_supervision(self):
+        detector = baselines.AlwaysNormal()
+        assert detector.supervision == Supervision.UNSUPERVISED
 
     def test_univariate(self, univariate_time_series):
         detector = baselines.AlwaysNormal()
@@ -29,6 +33,10 @@ class TestAlwaysNormal:
 
 class TestAlwaysAnomalous:
 
+    def test_supervision(self):
+        detector = baselines.AlwaysAnomalous()
+        assert detector.supervision == Supervision.UNSUPERVISED
+
     def test_univariate(self, univariate_time_series):
         detector = baselines.AlwaysAnomalous()
         y_pred = detector.fit(univariate_time_series).decision_function(univariate_time_series)
@@ -52,6 +60,10 @@ class TestAlwaysAnomalous:
 
 
 class TestRandomDetector:
+
+    def test_supervision(self):
+        detector = baselines.RandomDetector()
+        assert detector.supervision == Supervision.UNSUPERVISED
 
     def test_univariate(self, univariate_time_series):
         detector = baselines.RandomDetector()

--- a/tests/data/test_DataSet.py
+++ b/tests/data/test_DataSet.py
@@ -104,6 +104,45 @@ class TestCheckIsValid:
             DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=valid_X_train, y_train=np.append(valid_y_train, 0))
 
 
+class TestCompatibleSupervision:
+
+    def test_unsupervised_all_data(self, valid_X_test, valid_y_test, valid_X_train, valid_y_train):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=valid_X_train, y_train=valid_y_train)
+        assert Supervision.UNSUPERVISED in data_set.compatible_supervision()
+
+    def test_unsupervised_no_train_labels(self, valid_X_test, valid_y_test, valid_X_train):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=valid_X_train)
+        assert Supervision.UNSUPERVISED in data_set.compatible_supervision()
+
+    def test_unsupervised_no_train_data(self, valid_X_test, valid_y_test):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test)
+        assert Supervision.UNSUPERVISED in data_set.compatible_supervision()
+
+    def test_semi_supervised_all_data(self, valid_X_test, valid_y_test, valid_X_train, valid_y_train):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=valid_X_train, y_train=valid_y_train)
+        assert Supervision.SEMI_SUPERVISED in data_set.compatible_supervision()
+
+    def test_semi_supervised_no_train_labels(self, valid_X_test, valid_y_test, valid_X_train):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=valid_X_train)
+        assert Supervision.SEMI_SUPERVISED in data_set.compatible_supervision()
+
+    def test_semi_supervised_no_train_data(self, valid_X_test, valid_y_test):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test)
+        assert Supervision.SEMI_SUPERVISED not in data_set.compatible_supervision()
+
+    def test_supervised_all_data(self, valid_X_test, valid_y_test, valid_X_train, valid_y_train):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=valid_X_train, y_train=valid_y_train)
+        assert Supervision.SUPERVISED in data_set.compatible_supervision()
+
+    def test_supervised_no_train_labels(self, valid_X_test, valid_y_test, valid_X_train):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=valid_X_train)
+        assert Supervision.SUPERVISED not in data_set.compatible_supervision()
+
+    def test_supervised_no_train_data(self, valid_X_test, valid_y_test):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test)
+        assert Supervision.SUPERVISED not in data_set.compatible_supervision()
+
+
 class DummyDetector(BaseDetector):
 
     def __init__(self, supervision):

--- a/tests/data/test_DataSet.py
+++ b/tests/data/test_DataSet.py
@@ -1,0 +1,170 @@
+from typing import Optional
+
+import pytest
+import numpy as np
+from dtaianomaly.data import DataSet
+from dtaianomaly.anomaly_detection import BaseDetector,  Supervision
+
+
+@pytest.fixture
+def valid_X_test():
+    return np.array([0, 1, 2, 3, 4, 5])
+
+
+@pytest.fixture
+def valid_y_test():
+    return np.array([0, 0, 1, 0, 1, 0])
+
+
+@pytest.fixture
+def valid_X_train():
+    return np.array([0, 10, 20, 30, 40, 50, 60])
+
+
+@pytest.fixture
+def valid_y_train():
+    return np.array([0, 1, 1, 0, 0, 0, 0])
+
+
+class TestCheckIsValid:
+
+    def test_is_valid(self, valid_X_test, valid_y_test):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test)
+        assert data_set.is_valid()
+
+    def test_is_valid_given_train_data(self, valid_X_test, valid_y_test, valid_X_train):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=valid_X_train)
+        assert data_set.is_valid()
+
+    def test_is_valid_given_train_data_and_labels(self, valid_X_test, valid_y_test, valid_X_train, valid_y_train):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=valid_X_train, y_train=valid_y_train)
+        assert data_set.is_valid()
+
+    def test_not_is_valid(self, valid_X_test, valid_y_test):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test)
+        assert data_set.is_valid()
+        data_set.X_test = [0, 1, 2, 3, '4', 5]  # Make data invalid (should not be done!)
+        assert not data_set.is_valid()
+
+    def test_no_test_data(self, valid_y_test):
+        with pytest.raises(ValueError):
+            DataSet(X_test=None, y_test=valid_y_test)
+
+    def test_no_test_labels(self, valid_X_test):
+        with pytest.raises(ValueError):
+            DataSet(X_test=valid_X_test, y_test=None)
+
+    def test_invalid_X_test(self, valid_y_test):
+        with pytest.raises(ValueError):
+            DataSet(X_test=np.array([0, 1, 2, 3, '4', 5]), y_test=valid_y_test)
+
+    def test_invalid_y_test(self, valid_X_test):
+        with pytest.raises(ValueError):
+            DataSet(X_test=valid_X_test, y_test=np.array([0, 0, 1, 0, '1', 0]))
+
+    def test_multivariate_y_test(self, valid_X_test):
+        with pytest.raises(ValueError):
+            DataSet(X_test=valid_X_test, y_test=np.array([[0, 0], [0, 1], [1, 1], [0, 0], [1, 1], [0, 0]]))
+
+    def test_non_binary_y_test(self, valid_X_test):
+        with pytest.raises(ValueError):
+            DataSet(X_test=valid_X_test, y_test=np.array([0, 0, 1, 0.5, 1, 0]))
+
+    def test_test_data_and_labels_different_shape(self, valid_X_test, valid_y_test):
+        with pytest.raises(ValueError):
+            DataSet(X_test=valid_X_test, y_test=np.append(valid_y_test, 0))
+
+    def test_invalid_X_train(self, valid_X_test, valid_y_test):
+        with pytest.raises(ValueError):
+            DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=np.array([0, 1, 2, 3, '4', 5]))
+
+    def test_X_test_and_X_train_different_dimension(self, valid_X_test, valid_y_test, valid_X_train):
+        multivariate_valid_X_train = np.repeat(valid_X_train, 2).reshape(valid_X_train.shape[0], -1)
+        with pytest.raises(ValueError):
+            DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=multivariate_valid_X_train)
+
+    def test_valid_y_train_but_no_X_train(self, valid_X_test, valid_y_test, valid_y_train):
+        with pytest.raises(ValueError):
+            DataSet(X_test=valid_X_test, y_test=valid_y_test, y_train=valid_y_train)
+
+    def test_invalid_y_train(self, valid_X_test, valid_y_test, valid_X_train):
+        with pytest.raises(ValueError):
+            DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=valid_X_train, y_train=np.array([0, 0, 1, 0, '1', 0, 0]))
+
+    def test_multivariate_y_train(self, valid_X_test, valid_y_test, valid_X_train):
+        with pytest.raises(ValueError):
+            DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=valid_X_train, y_train=np.array([[0, 0], [0, 1], [1, 1], [0, 0], [1, 1], [0, 0], [1, 0]]))
+
+    def test_non_binary_y_train(self, valid_X_test, valid_y_test, valid_X_train):
+        with pytest.raises(ValueError):
+            DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=valid_X_train, y_train=np.array([0, 0, 1, 0.5, 1, 0, 0]))
+
+    def test_train_data_and_labels_different_shape(self, valid_X_test, valid_y_test, valid_X_train, valid_y_train):
+        with pytest.raises(ValueError):
+            DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=valid_X_train, y_train=np.append(valid_y_train, 0))
+
+
+class DummyDetector(BaseDetector):
+
+    def __init__(self, supervision):
+        super().__init__(supervision)
+
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'BaseDetector':
+        return self
+
+    def decision_function(self, X: np.ndarray) -> np.ndarray:
+        return np.zeros(X.shape[0])
+
+
+@pytest.fixture
+def unsupervised_detector() -> DummyDetector:
+    return DummyDetector(Supervision.UNSUPERVISED)
+
+
+@pytest.fixture
+def semisupervised_detector() -> DummyDetector:
+    return DummyDetector(Supervision.SEMI_SUPERVISED)
+
+
+@pytest.fixture
+def supervised_detector() -> DummyDetector:
+    return DummyDetector(Supervision.SUPERVISED)
+
+
+class TestCompatibleAnomalyDetector:
+
+    def test_no_train_data(self,
+                           unsupervised_detector,
+                           semisupervised_detector,
+                           supervised_detector,
+                           valid_X_test,
+                           valid_y_test):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test)
+        assert data_set.is_compatible(unsupervised_detector)
+        assert not data_set.is_compatible(semisupervised_detector)
+        assert not data_set.is_compatible(supervised_detector)
+
+    def test_no_train_labels(self,
+                             unsupervised_detector,
+                             semisupervised_detector,
+                             supervised_detector,
+                             valid_X_test,
+                             valid_y_test,
+                             valid_X_train):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=valid_X_train)
+        assert data_set.is_compatible(unsupervised_detector)
+        assert data_set.is_compatible(semisupervised_detector)
+        assert not data_set.is_compatible(supervised_detector)
+
+    def test_train_data(self,
+                        unsupervised_detector,
+                        semisupervised_detector,
+                        supervised_detector,
+                        valid_X_test,
+                        valid_y_test,
+                        valid_X_train,
+                        valid_y_train):
+        data_set = DataSet(X_test=valid_X_test, y_test=valid_y_test, X_train=valid_X_train, y_train=valid_y_train)
+        assert data_set.is_compatible(unsupervised_detector)
+        assert data_set.is_compatible(semisupervised_detector)
+        assert data_set.is_compatible(supervised_detector)

--- a/tests/data/test_LazyDataLoader.py
+++ b/tests/data/test_LazyDataLoader.py
@@ -8,7 +8,7 @@ from dtaianomaly.data import LazyDataLoader, DataSet, from_directory
 class DummyLoader(LazyDataLoader):
 
     def _load(self) -> DataSet:
-        return DataSet(x=np.array([]), y=np.array([]))
+        return DataSet(X_test=np.random.uniform(size=(1000, 3)), y_test=np.random.choice([0, 1], p=[0.95, 0.05], size=1000, replace=True))
 
 
 class TestLazyDataLoader:
@@ -30,12 +30,12 @@ class TestLazyDataLoader:
         assert str(DummyLoader(tmp_path)) == f"DummyLoader(path='{tmp_path}')"
 
 
-class CostlyDummyLoader(LazyDataLoader):
+class CostlyDummyLoader(DummyLoader):
     NB_SECONDS_SLEEP = 1.5
 
     def _load(self) -> DataSet:
         time.sleep(self.NB_SECONDS_SLEEP)
-        return DataSet(x=np.array([]), y=np.array([]))
+        return super()._load()
 
 
 class TestCaching:

--- a/tests/data/test_UCRLoader.py
+++ b/tests/data/test_UCRLoader.py
@@ -5,6 +5,7 @@ import numpy as np
 from dtaianomaly.data import UCRLoader, from_directory
 
 UCR_DATA_PATH = 'data/UCR-time-series-anomaly-archive'
+UCR_DATA_PATH = '../data/UCR-time-series-anomaly-archive'
 UCR_DATA_SET = '001_UCR_Anomaly_DISTORTED1sddb40_35000_52000_52620.txt'
 
 data_available = pytest.mark.skipif(
@@ -35,11 +36,11 @@ class TestUCRLoader:
 
     @data_available
     def test_contains_anomaly(self, loaded):
-        assert np.sum(loaded.y == 1) > 0
+        assert np.sum(loaded.y_test == 1) > 0
 
     @data_available
     def test_samples_match(self, loaded):
-        assert loaded.x.shape[0] == loaded.y.shape[0]
+        assert loaded.X_test.shape[0] == loaded.y_test.shape[0]
 
     def test_faulty_path(self):
         with pytest.raises(FileNotFoundError):

--- a/tests/data/test_UCRLoader.py
+++ b/tests/data/test_UCRLoader.py
@@ -5,7 +5,6 @@ import numpy as np
 from dtaianomaly.data import UCRLoader, from_directory
 
 UCR_DATA_PATH = 'data/UCR-time-series-anomaly-archive'
-UCR_DATA_PATH = '../data/UCR-time-series-anomaly-archive'
 UCR_DATA_SET = '001_UCR_Anomaly_DISTORTED1sddb40_35000_52000_52620.txt'
 
 data_available = pytest.mark.skipif(

--- a/tests/pipeline/test_EvaluationPipeline.py
+++ b/tests/pipeline/test_EvaluationPipeline.py
@@ -38,25 +38,35 @@ class TestEvaluationPipeline:
         with pytest.raises(TypeError):
             EvaluationPipeline(ZNormalizer(), IsolationForest(15), [AreaUnderROC(), 'AreaUnderPR'])
 
-    def test_run_invalid_x(self):
+    def test_run_invalid_X_test(self):
         pipeline = EvaluationPipeline(Identity(), IsolationForest(15), AreaUnderROC())
         with pytest.raises(ValueError):
-            pipeline.run(['3', '5', '7'], np.array([0, 1, 0]))
+            pipeline.run(['3', '5', '7'], np.array([0, 1, 0]), np.array([1, 2, 3]), None)
 
-    def test_run_invalid_y(self, univariate_time_series):
+    def test_run_invalid_y_test(self, univariate_time_series):
         pipeline = EvaluationPipeline(Identity(), IsolationForest(15), AreaUnderROC())
         with pytest.raises(ValueError):
-            pipeline.run(np.array([3, 5, 7]), ['0', '1', '0'])
+            pipeline.run(np.array([3, 5, 7]), ['0', '1', '0'], np.array([1, 2, 3]), None)
 
-    def test_run_none_y(self, univariate_time_series):
+    def test_run_none_y_test(self, univariate_time_series):
         pipeline = EvaluationPipeline(Identity(), IsolationForest(15), AreaUnderROC())
         with pytest.raises(ValueError):
-            pipeline.run(np.array([3, 5, 7]), None)
+            pipeline.run(np.array([3, 5, 7]), None, np.array([1, 2, 3]), None)
+
+    def test_run_invalid_X_train(self):
+        pipeline = EvaluationPipeline(Identity(), IsolationForest(15), AreaUnderROC())
+        with pytest.raises(ValueError):
+            pipeline.run([3, 5, 7], np.array([0, 1, 0]), np.array(['1', '2', '3']), None)
+
+    def test_run_invalid_y_train(self, univariate_time_series):
+        pipeline = EvaluationPipeline(Identity(), IsolationForest(15), AreaUnderROC())
+        with pytest.raises(ValueError):
+            pipeline.run(np.array([3, 5, 7]), [0, 1, 0], np.array([1, 2, 3]), np.array(['0', '1', '0']))
 
     def test_run(self, univariate_time_series):
         pipeline = EvaluationPipeline(ZNormalizer(), IsolationForest(15), [AreaUnderROC(), AreaUnderPR()])
         y = np.random.choice([0, 1], size=univariate_time_series.shape[0], replace=True)
-        results = pipeline.run(univariate_time_series, y)
+        results = pipeline.run(univariate_time_series, y, univariate_time_series, None)
         assert len(results) == 2
         assert 'AreaUnderROC()' in results
         assert 'AreaUnderPR()' in results
@@ -64,7 +74,7 @@ class TestEvaluationPipeline:
     def test_run_multivariate(self, multivariate_time_series):
         pipeline = EvaluationPipeline(ZNormalizer(), IsolationForest(15), [AreaUnderROC(), AreaUnderPR()])
         y = np.random.choice([0, 1], size=multivariate_time_series.shape[0], replace=True)
-        results = pipeline.run(multivariate_time_series, y)
+        results = pipeline.run(multivariate_time_series, y, multivariate_time_series, y)
         assert len(results) == 2
         assert 'AreaUnderROC()' in results
         assert 'AreaUnderPR()' in results
@@ -72,7 +82,7 @@ class TestEvaluationPipeline:
     def test_shorter_y(self, univariate_time_series):
         pipeline = EvaluationPipeline(SamplingRateUnderSampler(5), IsolationForest(15), [AreaUnderROC(), AreaUnderPR()])
         y = np.random.choice([0, 1], size=univariate_time_series.shape[0], replace=True)
-        results = pipeline.run(univariate_time_series, y)
+        results = pipeline.run(univariate_time_series, y, univariate_time_series, None)
         assert len(results) == 2
         assert 'AreaUnderROC()' in results
         assert 'AreaUnderPR()' in results

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,9 @@
 
+import pytest
 import numpy as np
 from typing import Any
 
-from dtaianomaly.utils import is_valid_list, is_valid_array_like, is_univariate
+from dtaianomaly.utils import is_valid_list, is_valid_array_like, is_univariate, get_dimension
 
 
 class TestIsValidList:
@@ -100,6 +101,9 @@ class TestIsValidArrayLike:
     def test_invalid_bool(self):
         assert not is_valid_array_like(True)
 
+    def test_invalid_none(self):
+        assert not is_valid_array_like(None)
+
     def test_invalid_multivariate_list_type(self):
         assert not is_valid_array_like([[1, 10], [2, 20], [3, 30], [4, 40], [5, '50']])
 
@@ -136,3 +140,17 @@ class TestIsUnivariate:
 
     def test_univariate_list(self, univariate_time_series):
         assert is_univariate([i for i in univariate_time_series])
+
+
+class TestGetDimension:
+
+    def test_single_dimension(self):
+        rng = np.random.default_rng(42)
+        X = np.random.uniform(size=1000)
+        assert get_dimension(X) == 1
+
+    @pytest.mark.parametrize('dimension', [1, 2, 3, 5, 10])
+    def test_dimension(self, dimension):
+        rng = np.random.default_rng(42)
+        X = np.random.uniform(size=(1000, dimension))
+        assert get_dimension(X) == dimension

--- a/tests/workflow/test_WorkFlow.py
+++ b/tests/workflow/test_WorkFlow.py
@@ -1,13 +1,12 @@
 
 import pytest
-import numpy as np
 
 from dtaianomaly.workflow import Workflow
 from dtaianomaly.data import UCRLoader, LazyDataLoader, DataSet, demonstration_time_series
 from dtaianomaly.evaluation import Precision, Recall, AreaUnderROC
 from dtaianomaly.thresholding import TopN, FixedCutoff
 from dtaianomaly.preprocessing import Identity, ZNormalizer, Preprocessor
-from dtaianomaly.anomaly_detection import MatrixProfileDetector, IsolationForest, LocalOutlierFactor, BaseDetector
+from dtaianomaly.anomaly_detection import MatrixProfileDetector, IsolationForest, LocalOutlierFactor, BaseDetector, Supervision
 
 
 class TestWorkflowInitialization:
@@ -284,6 +283,9 @@ class PreprocessorError(Preprocessor):
 
 
 class DetectorError(BaseDetector):
+
+    def __init__(self):
+        super().__init__(Supervision.UNSUPERVISED)
 
     def fit(self, X, y=None):
         return self

--- a/tests/workflow/test_WorkFlow.py
+++ b/tests/workflow/test_WorkFlow.py
@@ -470,11 +470,12 @@ class TestGetTrainTestData:
             X_train=np.array([10, 20, 30, 40, 50])
         )
         detector = DummyDetector(Supervision.UNSUPERVISED)
-        X_test, y_test, X_train, y_train = _get_train_test_data(data_set, detector, fit_unsupervised_on_test_data=True)
+        X_test, y_test, X_train, y_train, fit_on_X_train = _get_train_test_data(data_set, detector, fit_unsupervised_on_test_data=True)
         assert np.array_equal(data_set.X_test, X_test)
         assert np.array_equal(data_set.y_test, y_test)
         assert np.array_equal(data_set.X_test, X_train)
         assert y_train is None
+        assert not fit_on_X_train
 
     def test_unsupervised_do_not_use_test_set_for_fit(self):
         data_set = DataSet(
@@ -483,11 +484,12 @@ class TestGetTrainTestData:
             X_train=np.array([10, 20, 30, 40, 50])
         )
         detector = DummyDetector(Supervision.UNSUPERVISED)
-        X_test, y_test, X_train, y_train = _get_train_test_data(data_set, detector, fit_unsupervised_on_test_data=False)
+        X_test, y_test, X_train, y_train, fit_on_X_train = _get_train_test_data(data_set, detector, fit_unsupervised_on_test_data=False)
         assert np.array_equal(data_set.X_test, X_test)
         assert np.array_equal(data_set.y_test, y_test)
         assert np.array_equal(data_set.X_train, X_train)
         assert y_train is None
+        assert fit_on_X_train
 
     def test_semi_supervised_use_test_set_for_fit(self):
         data_set = DataSet(
@@ -496,11 +498,12 @@ class TestGetTrainTestData:
             X_train=np.array([10, 20, 30, 40, 50])
         )
         detector = DummyDetector(Supervision.SEMI_SUPERVISED)
-        X_test, y_test, X_train, y_train = _get_train_test_data(data_set, detector, fit_unsupervised_on_test_data=True)
+        X_test, y_test, X_train, y_train, fit_on_X_train = _get_train_test_data(data_set, detector, fit_unsupervised_on_test_data=True)
         assert np.array_equal(data_set.X_test, X_test)
         assert np.array_equal(data_set.y_test, y_test)
         assert np.array_equal(data_set.X_train, X_train)
         assert y_train is None
+        assert fit_on_X_train
 
     def test_semi_supervised_do_not_use_test_set_for_fit(self):
         data_set = DataSet(
@@ -509,8 +512,9 @@ class TestGetTrainTestData:
             X_train=np.array([10, 20, 30, 40, 50])
         )
         detector = DummyDetector(Supervision.SEMI_SUPERVISED)
-        X_test, y_test, X_train, y_train = _get_train_test_data(data_set, detector, fit_unsupervised_on_test_data=False)
+        X_test, y_test, X_train, y_train, fit_on_X_train = _get_train_test_data(data_set, detector, fit_unsupervised_on_test_data=False)
         assert np.array_equal(data_set.X_test, X_test)
         assert np.array_equal(data_set.y_test, y_test)
         assert np.array_equal(data_set.X_train, X_train)
         assert y_train is None
+        assert fit_on_X_train

--- a/tests/workflow/test_error_logging.py
+++ b/tests/workflow/test_error_logging.py
@@ -159,13 +159,12 @@ class TestErrorLogging:
         assert error_file_contains_error(error_file, error)
         assert error_file_results_in_error(error_file, error)
 
-
     def test_log_no_exception(self, tmp_path_factory):
         error = Exception('Dummy')
         error_file = log_error(
             error_log_path=str(tmp_path_factory.mktemp('error-log')),
             exception=Exception('Dummy'),
-            data_loader=DemonstrationDataLoader(),
+            data_loader=DemonstrationDataLoaderWithTrainData(),
             pipeline=Pipeline(
                 preprocessor=Identity(),
                 detector=IsolationForest(15)
@@ -199,6 +198,7 @@ def error_file_results_in_error(error_file, error):
 
 def error_file_runs_successfully(error_file):
     output = _run_error_file(error_file)
+    print(output)
     return output.returncode == 0
 
 
@@ -211,6 +211,8 @@ def _run_error_file(error_file):
     # Add this file as import
     with open(error_file, 'r+') as file:
         content = file.read()
+        print()
+        print(content)
         file.seek(0, 0)
         file.write(f'from {pathlib.Path(__file__).stem} import *\n' + content)
 

--- a/tests/workflow/test_error_logging.py
+++ b/tests/workflow/test_error_logging.py
@@ -6,7 +6,7 @@ import subprocess
 import pathlib
 
 from dtaianomaly.data import LazyDataLoader, DataSet, demonstration_time_series
-from dtaianomaly.anomaly_detection import BaseDetector, IsolationForest
+from dtaianomaly.anomaly_detection import BaseDetector, IsolationForest, Supervision
 from dtaianomaly.preprocessing import Preprocessor, Identity, ChainedPreprocessor
 from dtaianomaly.pipeline import Pipeline
 from dtaianomaly.evaluation import AreaUnderROC
@@ -40,6 +40,9 @@ class ErrorPreprocessor(Preprocessor):
 
 
 class ErrorAnomalyDetector(BaseDetector):
+
+    def __init__(self):
+        super().__init__(Supervision.UNSUPERVISED)
 
     def fit(self, X, y=None):
         return self

--- a/tests/workflow/test_utils.py
+++ b/tests/workflow/test_utils.py
@@ -1,6 +1,6 @@
 
 from dtaianomaly.anomaly_detection import IsolationForest, LocalOutlierFactor
-from dtaianomaly.evaluation import AreaUnderROC, Precision, Recall, ThresholdMetric
+from dtaianomaly.evaluation import AreaUnderROC, Precision, ThresholdMetric
 from dtaianomaly.thresholding import FixedCutoff, ContaminationRate
 from dtaianomaly.preprocessing import Identity, ZNormalizer, ChainedPreprocessor
 from dtaianomaly.workflow.utils import build_pipelines, convert_to_proba_metrics, convert_to_list


### PR DESCRIPTION
Steps:
- [x] Include both training and test data in ``DataSet`` object
- [x] Add a supervision label to ``BaseDetector`` to check compatibility with a ``DataSet``
- [x] Integrate the supervision in the ``Workflow`` + add Additional tests for this
- [x] Adapt industrial example to include the new ``DataSet``
- [x] Use train data in the ``UCRDataLoader``

Would it be useful to include a parameter to read the train data in data loaders? For example for the ``UCRLoader``, you can choose if the train data should be read or not (i.e., whether ``DataSet.X_train`` should be set). This way, we enable the possiblity to fit the detector on the contaminated test data and check its performance. 