### PR TITLE
Included dev as optional dependency

### DIFF
--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          pip install .[docs]
           pip list
 
       # Change the directory to the docs directory.

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -30,18 +30,12 @@ jobs:
         with:
           python-version: '3.10'  # Only for one python version to save on resources
 
-      # Install dependencies
-      - name: Install dependencies
+      # Install dtaianomaly + all dependencies
+      - name: Install dtaianomaly
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
-          pip install nbconvert jupyter
+          pip install .[all]
           pip list
-
-      # Install dtaianomaly locally
-      - name: Install dtaianomaly
-        run: pip install .
 
       # Test the notebooks
       - name: Execute Anomaly detection notebook

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13""]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,6 +31,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[all]
+        pip install flake8
         pip list
 
     - name: Lint with flake8

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13""]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,12 +26,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
+    # Install dtaianomaly + all dependencies
+    - name: Install dtaianomaly
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r requirements-dev.txt
-        pip install flake8
+        pip install .[all]
         pip list
 
     - name: Lint with flake8

--- a/docs/additional_information/changelog.rst
+++ b/docs/additional_information/changelog.rst
@@ -13,6 +13,9 @@ Added
 - Implemented ``KMeansAnomalyDetector`` anomaly detector.
 - Implemented ``CopulaBasedOutlierDetector`` (COPOD) anomaly detector.
 - Implemented ``RobustScaler`` preprocessor.
+- Added optional dependencies to ``dtaianomaly``, rather than having to install
+  everything via different requirements files.
+- Added support for Python 3.13.
 
 Changed
 ^^^^^^^

--- a/docs/additional_information/contributing.rst
+++ b/docs/additional_information/contributing.rst
@@ -81,13 +81,13 @@ Setup the environment
 Next, you can set up your environment to start working on the issue.
 For this, we highly recommend to `virtual environment <https://docs.python.org/3/library/venv.html>`_
 to isolate the dependencies. To install the dependencies of
-``dtaianomaly``, including the development dependencies,
+``dtaianomaly``, including all optional dependencies,
 navigate to the directory where you downloaded the code and
 run the following command:
 
 .. code-block:: bash
 
-     pip install --editable .[dev]
+     pip install --editable .[all]
 
 You should include the ``--editable`` flag to ensure that your
 changes to the code are actually reflected in the installed version.

--- a/docs/additional_information/contributing.rst
+++ b/docs/additional_information/contributing.rst
@@ -80,20 +80,17 @@ Setup the environment
 
 Next, you can set up your environment to start working on the issue.
 For this, we highly recommend to `virtual environment <https://docs.python.org/3/library/venv.html>`_
-to isolate the dependencies. To install the core-dependencies (e.g.,
-`Numpy <https://numpy.org/>`_) of``dtaianomaly``, run the following
-command:
+to isolate the dependencies. To install the dependencies of
+``dtaianomaly``, including the development dependencies,
+navigate to the directory where you downloaded the code and
+run the following command:
 
 .. code-block:: bash
 
-     pip install -r requirements.txt
+     pip install --editable .[dev]
 
-In addition, you should also install the development dependencies
-(e.g., `pytest <https://docs.pytest.org/en/stable/>`_) as follows:
-
-.. code-block:: bash
-
-     pip install -r requirements-dev.txt
+You should include the ``--editable`` flag to ensure that your
+changes to the code are actually reflected in the installed version.
 
 To check if the environment is correct, you verify if all tests
 succeed by running the following command (which also checks the
@@ -248,7 +245,7 @@ BaseDetector
 | |check_box| Have you implemented the :py:func:`~dtaianomaly.anomaly_detection.BaseDetector.fit()` method?
 | |check_box| Have you implemented the :py:func:`~dtaianomaly.anomaly_detection.BaseDetector.decision_function()` method?
 | |check_box| Did you add the anomaly detector in ``__all__`` of the ``dtaianomaly/anomaly_detection/__init__.py`` file?
-| |check_box| Can you load the anomaly detector via :py:func:`~dtaianomaly.workflow.interpret_config`` (specifically, in the ``detector_entry()`` function)?
+| |check_box| Can you load the anomaly detector via :py:func:`~dtaianomaly.workflow.interpret_config` (specifically, in the ``detector_entry()`` function)?
 
 .. rubric:: Test the anomaly detector
 
@@ -277,7 +274,7 @@ LazyDataLoader
 | |check_box| Are all hyperparameters set as an attribute of the object (necessary for ``__str__()`` method)?
 | |check_box| Have you implemented the :py:func:`~dtaianomaly.data.LazyDataLoader._load()` method?
 | |check_box| Did you add the data loader in ``__all__`` of the ``dtaianomaly/data/__init__.py`` file?
-| |check_box| Can you load the data loader via :py:func:`~dtaianomaly.workflow.interpret_config`` (specifically, in the ``data_entry()`` function)?
+| |check_box| Can you load the data loader via :py:func:`~dtaianomaly.workflow.interpret_config` (specifically, in the ``data_entry()`` function)?
 
 .. rubric:: Test the data loader
 
@@ -306,7 +303,7 @@ Preprocessor
 | |check_box| Have you implemented the :py:func:`~dtaianomaly.preprocessing.Preprocessor._fit()` method?
 | |check_box| Have you implemented the :py:func:`~dtaianomaly.preprocessing.Preprocessor._transform()` method?
 | |check_box| Did you add the preprocessor in ``__all__`` of the ``dtaianomaly/preprocessing/__init__.py`` file?
-| |check_box| Can you load the preprocessor via :py:func:`~dtaianomaly.workflow.interpret_config`` (specifically, in the ``preprocessor_entry()`` function)?
+| |check_box| Can you load the preprocessor via :py:func:`~dtaianomaly.workflow.interpret_config` (specifically, in the ``preprocessor_entry()`` function)?
 
 .. rubric:: Test the preprocessor
 
@@ -334,7 +331,7 @@ Thresholding
 | |check_box| Are all hyperparameters set as an attribute of the object (necessary for ``__str__()`` method)?
 | |check_box| Have you implemented the :py:func:`~dtaianomaly.thresholding.Thresholder.threshold()` method?
 | |check_box| Did you add the thresholder in ``__all__`` of the ``dtaianomaly/thresholding/__init__.py`` file?
-| |check_box| Can you load the thresholder via :py:func:`~dtaianomaly.workflow.interpret_config`` (specifically, in the `threshold_entry()`` function)?
+| |check_box| Can you load the thresholder via :py:func:`~dtaianomaly.workflow.interpret_config` (specifically, in the `threshold_entry()`` function)?
 
 .. rubric:: Test the thresholder
 

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -11,25 +11,28 @@ Use the following command to install the latest version:
 
     pip install dtaianomaly
 
+Some dependencies are optional to ensure that ``dtaianomaly`` remains
+lightweight. Use the following command to install all optional
+dependencies:
+
+.. code-block:: bash
+
+    pip install dtaianomaly[all]
+
+It is also possible to only install a subset of the optional dependencies.
+You can install these by replacing 'all' with the corresponding name in the
+command above. To install multiple subsets, separate the names with a comma.
+Currently, following subsets are available:
+
+- ``tests``: Dependencies for running the tests.
+- ``docs``: Dependencies for generating the documentation.
+- ``notebooks``: Dependencies for using jupyter notebooks.
+
 To install version ``X.Y.Z``, use the following command:
 
 .. code-block:: bash
 
     pip install dtaianomaly==X.Y.Z
-
-Some dependencies are optional to ensure that ``dtaianomaly`` remains
-lightweight. Use the following command to install the set of optional
-dependencies ``X``:
-
-.. code-block:: bash
-
-    pip install dtaianomaly[X]
-
-Multiple sets of optional dependencies can be installed by separating
-them with a comma. Currently, following sets of optional dependencies
-are available:
-- ``dev``: dependencies regarding the development of ``dtaianomaly``,
-  including testing and creating the documentation.
 
 
 From GitHub

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -17,6 +17,20 @@ To install version ``X.Y.Z``, use the following command:
 
     pip install dtaianomaly==X.Y.Z
 
+Some dependencies are optional to ensure that ``dtaianomaly`` remains
+lightweight. Use the following command to install the set of optional
+dependencies ``X``:
+
+.. code-block:: bash
+
+    pip install dtaianomaly[X]
+
+Multiple sets of optional dependencies can be installed by separating
+them with a comma. Currently, following sets of optional dependencies
+are available:
+- ``dev``: dependencies regarding the development of ``dtaianomaly``,
+  including testing and creating the documentation.
+
 
 From GitHub
 -----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "dtaianomaly"
 version = "0.2.3"
 description = "A simple-to-use Python package for time series anomaly detection!"
-requires-python = ">=3.8,<=3.12"
+requires-python = ">=3.8,<3.14"
 authors = [
     {name = "Louis Carpentier", email = "louis.carpentier@kuleuven.be"}
 ]
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "numpy>=1.22",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,17 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dynamic = ["dependencies",  "optional-dependencies"]
+dependencies = [
+    "numpy>=1.22",
+    "scipy>=1.10",
+    "numba>=0.58",
+    "stumpy>=1.12",
+    "scikit-learn>=1.3",
+    "pandas>=1.3.0",
+    "matplotlib>=3.7",
+    "statsmodels>=0.6",
+    "pyod>=2.0.0"
+]
 
 [project.readme]
 file = "README.md"
@@ -39,9 +49,28 @@ build-backend = "setuptools.build_meta"
 include = ["dtaianomaly", "dtaianomaly.*"]  # alternatively: `exclude = ["additional*"]`
 namespaces = false
 
-[tool.setuptools.dynamic.dependencies]
-file = ["requirements.txt"]
-
-[tool.setuptools.dynamic.optional-dependencies.dev]
-file = ["requirements-dev.txt"]
-
+[project.optional-dependencies]
+all = [  # All the optional dependencies
+    "sphinx",
+    "sphinx-rtd-theme",
+    "numpydoc",
+    "toml",
+    "pytest",
+    "pytest-cov",
+    "notebook",
+    "jupyterlab",
+]
+tests = [  # For testing
+    "pytest",
+    "pytest-cov"
+]
+docs = [  # For generating the docs
+    "sphinx",
+    "sphinx-rtd-theme",
+    "numpydoc",
+    "toml"
+]
+notebooks = [  # For using notebooks
+    "notebook",
+    "jupyterlab",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dynamic = ["dependencies"]
+dynamic = ["dependencies",  "optional-dependencies"]
 
 [project.readme]
 file = "README.md"
@@ -41,3 +41,7 @@ namespaces = false
 
 [tool.setuptools.dynamic.dependencies]
 file = ["requirements.txt"]
+
+[tool.setuptools.dynamic.optional-dependencies.dev]
+file = ["requirements-dev.txt"]
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,0 @@
-sphinx
-sphinx-rtd-theme
-numpydoc
-toml
-pytest
-pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-numpy>=1.22
-scipy>=1.10
-numba>=0.58
-stumpy>=1.12
-scikit-learn>=1.3
-pandas>=1.3.0
-matplotlib>=3.7
-statsmodels>=0.6
-pyod>=2.0.0


### PR DESCRIPTION
Adding the developer dependencies as optional, for easy installation. This pull request will be extended to further clean up installation. 

- [x] Add the dependencies literally in pyproject.toml
- [x] Remove the requirements.txt files
- [x] Remove requirements as dynamic in pyproject.toml
- [x] Include an optional set of dependencies 'all', for all the optional dependencies
- [x] Update documentation (specifically, installation guide and the contributing guide)